### PR TITLE
Automatic downloads and naming schema for media servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ein kleines Skript bzw. Tool zum herunterladen von Videos bei [ARD Plus](https:/
 - Shell/Bash (z.B. macOS Terminal)
 - [jq](https://jqlang.github.io/jq/)
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp)
-- Gnu-Tools: curl, grep, awk, echo, cut, sed, base64
+- Gnu-Tools: curl, grep, awk, echo, cut, sed, base64, tr
 - ARD Plus [Mitgliedschaft](https://www.ardplus.de/) (14 Tage kostenlos)
 
 ## Benutzung
@@ -15,7 +15,6 @@ Skript [downloaden](https://raw.githubusercontent.com/marco79cgn/ard-plus-dl/ref
 Anschließend das Skript aufrufen und drei Parameter mitgeben:
 `./ard-plus-dl.sh <url> <username> <password>` 
 
-Die `<url>` ist die Übersichtsseite eines Films oder einer Serie bei ARD Plus, zum Beispiel 
 
 - Gegen den Wind (Serie):
 `https://www.ardplus.de/details/a0T0100000064DB-gegen-den-wind`
@@ -24,6 +23,9 @@ Die `<url>` ist die Übersichtsseite eines Films oder einer Serie bei ARD Plus, 
 
 Das Skript erkennt automatisch, ob es sich um einen Film oder eine Serie handelt. Filme werden unmittelbar geladen. Im Falle einer Serie werden alle gefundenen Staffeln aufgelistet und zur Auswahl angeboten. 
 
+Vor den drei Parametern kann optional noch "--automatic" angegeben werden: Falls dieses Flag übergeben wird, erfolgt der Download automatisch ohne Rückfrage; bei Serien werden dann automatisch alle Staffeln heruntergeladen. Falls der Download abbrechen oder z.B. eine Staffel nicht geladen werden sollte, kann das Skript einfach erneut gestartet werden; es werden nur die fehlenden Episoden heruntergeladen.
+
+Die `<url>` ist die Übersichtsseite eines Films oder einer Serie bei ARD Plus, zum Beispiel 
 Filme und Serien werden automatisch mit mehreren Tonspuren geladen (z.B. deutsch & englisch), sofern verfügbar. Auch die Untertitel werden berücksichtigt.
 
 Es können zusätzlich zu Filmen und Serien auch ganze Tatort Ausgaben pro Stadt geladen werden, z.B. alle Folgen aus Bremen mit der URL:

--- a/ard-plus-dl.sh
+++ b/ard-plus-dl.sh
@@ -35,7 +35,7 @@ login() {
     -H 'origin: https://www.ardplus.de' \
     -H 'referer: https://www.ardplus.de/' \
     -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36' \
-    --data-raw "username=${encoded_username}&password=${encoded_password}" | grep -i authorization | awk '{print $3}')
+    --data-raw "username=${encoded_username}&password=${encoded_password}" | grep -i authorization | awk '{print $3}' | tr -d \\r)
     tokenType=$(echo $token | cut -f1 -d "." | base64 -d | jq -r '.typ')
     if [[ "$tokenType" == "JWT" ]]; then
         echo $token > $FILE

--- a/ard-plus-dl.sh
+++ b/ard-plus-dl.sh
@@ -4,6 +4,13 @@ curlBin=$(which curl)
 #curlBin=/snap/bin/curl
 FILE=ard-plus-token
 # parse input parameter
+if [ "$1" == "--automatic" ]
+then
+  automatic_download=1
+  shift
+else
+  automatic_download=0
+fi
 ardPlusUrl=$1
 username=$2
 password=$3
@@ -146,45 +153,58 @@ if [[ "$movie" != null ]]; then
 elif [[ "$tvshow" != null ]]; then
     requestedShow=$(echo "$contentResult" | jq '.data.series.title')
     seasonIds=$(echo "$contentResult" | jq '[.data.series.seasons.nodes[] | { season: .seasonInSeries, seasonId: .id, title: .title }]')
+    seasonCount=$(echo "$contentResult" | jq '[.data.series.seasons.nodes[] | { season: .seasonId }] | length')
     seasonOutput=$(echo "$seasonIds" | jq '[.[] | { Option: .season, Titel: .title }]' | jq -r '(.[0]|keys_unsorted|(.,map(length*"-"))),.[]|map(.)|@tsv'|column -ts $'\t')
     echo -e "\nGewünschte Serie: $requestedShow\n"
     echo -e "$seasonOutput\n"
 
-    echo -n "Welche Staffel möchtest du runterladen? "
-    read -r selectedSeason
-    selectedSeasonId=$(echo "$seasonIds" | jq -r --argjson index 1 ".[$((selectedSeason - 1))].seasonId")
-
-    seasonData=$("$curlBin" -s "https://data.ardplus.de/ard/graphql?extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22134d75e1e68a9599d1cdccf790839d9d71d2e7d7dca57d96f95285fcfd02b2ae%22%7D%7D&variables=%7B%22seasonId%22%3A%22$selectedSeasonId%22%7D&operationName=EpisodesInSeasonData" \
-    -H 'authority: data.ardplus.de' \
-    -H 'content-type: application/json' \
-    -H "cookie: sid=$token" \
-    -H 'origin: https://www.ardplus.de' \
-    -H 'referer: https://www.ardplus.de/' \
-    -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36')
-    episodes=$(echo $seasonData | jq '[.data.episodes.nodes[] | { id: .id, episodeNo: .episodeInSeason, title: .title, videoUrl: .videoSource.dashUrl }]')
-    amount=$(echo $episodes | jq '. | length')
-    echo -e "\nStaffel $selectedSeason hat $amount Folgen."
-    selectedSeasonFormatted=$(printf '%02d\n' "$selectedSeason")
-
-    if [[ $skip != "1" ]]; then
-        echo "Überspringe $skip Episode(n)."
-        skip=$((skip + 1))
+    if [ $automatic_download -eq 0 ]
+    then
+        echo -n "Welche Staffel möchtest du runterladen? "
+        read -r selectedSeasonList
+    else
+        selectedSeasonList=$(seq 1 $seasonCount)
     fi
 
-    # loop over all episodes and download each
-    while read episode
+    # loop over all seasons
+    for selectedSeason in $selectedSeasonList
     do
-        movieId=$(echo "$episode" | jq -r '.id')
-        name=$(echo "$episode" | jq -r '.title')
-        videoUrl=$(echo "$episode" | jq -r '.videoUrl')
-        episode=$(echo "$episode" | jq -r '.episodeNo')
-        filename="S${selectedSeasonFormatted}E$(printf '%02d\n' $episode) - ${name}"
-        urlParam=$( auth )
-        downloadUrl=${videoUrl}?${urlParam}
-        echo "Lade ${filename}..."
-        yt-dlp --quiet --progress --no-warnings --audio-multistreams -f "bv+mergeall[vcodec=none]" --sub-langs "en.*,de.*" --embed-subs --merge-output-format mp4 ${downloadUrl} -o "$filename"
-        cleanup
-    done < <(echo "$episodes" | sed 's/\\"//g' | jq -c '.[]' | tail -n +$skip)
+        selectedSeasonId=$(echo "$seasonIds" | jq -r --argjson index 1 ".[$((selectedSeason - 1))].seasonId")
+
+        seasonData=$("$curlBin" -s "https://data.ardplus.de/ard/graphql?extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22134d75e1e68a9599d1cdccf790839d9d71d2e7d7dca57d96f95285fcfd02b2ae%22%7D%7D&variables=%7B%22seasonId%22%3A%22$selectedSeasonId%22%7D&operationName=EpisodesInSeasonData" \
+        -H 'authority: data.ardplus.de' \
+        -H 'content-type: application/json' \
+        -H "cookie: sid=$token" \
+        -H 'origin: https://www.ardplus.de' \
+        -H 'referer: https://www.ardplus.de/' \
+        -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36')
+        episodes=$(echo $seasonData | jq '[.data.episodes.nodes[] | { id: .id, episodeNo: .episodeInSeason, title: .title, videoUrl: .videoSource.dashUrl }]')
+        amount=$(echo $episodes | jq '. | length')
+        echo -e "\nStaffel $selectedSeason hat $amount Folgen."
+        selectedSeasonFormatted=$(printf '%02d\n' "$selectedSeason")
+
+        if [[ $skip != "1" ]]; then
+            echo "Überspringe $skip Episode(n)."
+            skip=$((skip + 1))
+        fi
+
+        # loop over all episodes and download each
+        while read episode
+        do
+            movieId=$(echo "$episode" | jq -r '.id')
+            name=$(echo "$episode" | jq -r '.title')
+            videoUrl=$(echo "$episode" | jq -r '.videoUrl')
+            episode=$(echo "$episode" | jq -r '.episodeNo')
+            filename="S${selectedSeasonFormatted}E$(printf '%02d\n' $episode) - ${name}"
+            urlParam=$( auth )
+            downloadUrl=${videoUrl}?${urlParam}
+            echo "Lade ${filename}..."
+            yt-dlp --quiet --progress --no-warnings --audio-multistreams -f "bv+mergeall[vcodec=none]" --sub-langs "en.*,de.*" --embed-subs --merge-output-format mp4 ${downloadUrl} -o "$filename"
+            cleanup
+        done < <(echo "$episodes" | sed 's/\\"//g' | jq -c '.[]' | tail -n +$skip)
+
+    done
+
 elif [[ "$ardPlusUrl" == *"tatort"* ]]; then
     tatortCity=$(echo $showPath | cut -d "-" -f2)
     # get all episodes per city
@@ -200,9 +220,14 @@ elif [[ "$ardPlusUrl" == *"tatort"* ]]; then
     amount=$(echo $episodeIds | jq '. | length')
     cityCapitalized=$(echo ${tatortCity} | awk '{$1=toupper(substr($1,0,1))substr($1,2)}1')
     echo "Der Tatort ${cityCapitalized} hat $amount Episoden."
-    echo -n "Wie viele Episoden möchtest du überspringen? (0=alle laden) "
-    read -r skip
-    echo "Überspringe $skip Episode(n)."
+    if [ $automatic_download -eq 0 ]
+    then
+        echo -n "Wie viele Episoden möchtest du überspringen? (0=alle laden) "
+        read -r skip
+        echo "Überspringe $skip Episode(n)."
+    else
+        skip=0
+    fi
     skip=$((skip + 1))
 
     # loop over all episodes and download each

--- a/ard-plus-dl.sh
+++ b/ard-plus-dl.sh
@@ -144,14 +144,14 @@ if [[ "$movie" != null ]]; then
     name=$(echo "$movie" | jq -r '.title')
     videoUrl=$(echo "$movie" | jq -r '.videoSource.dashUrl')
     year=$(echo "$movie" | jq -r '.productionYear')
-    filename="${name} (${year})"
+    filename="${name} (${year})/${name}"
     urlParam=$( auth )
     downloadUrl=${videoUrl}?${urlParam}
     echo "Lade Film ${filename}..."
     yt-dlp --quiet --progress --no-warnings --audio-multistreams -f "bv+mergeall[vcodec=none]" --sub-langs "en.*,de.*" --embed-subs --merge-output-format mp4 ${downloadUrl} -o "$filename"
     cleanup
 elif [[ "$tvshow" != null ]]; then
-    requestedShow=$(echo "$contentResult" | jq '.data.series.title')
+    requestedShow=$(echo "$contentResult" | jq -r '.data.series.title')
     seasonIds=$(echo "$contentResult" | jq '[.data.series.seasons.nodes[] | { season: .seasonInSeries, seasonId: .id, title: .title }]')
     seasonCount=$(echo "$contentResult" | jq '[.data.series.seasons.nodes[] | { season: .seasonId }] | length')
     seasonOutput=$(echo "$seasonIds" | jq '[.[] | { Option: .season, Titel: .title }]' | jq -r '(.[0]|keys_unsorted|(.,map(length*"-"))),.[]|map(.)|@tsv'|column -ts $'\t')
@@ -195,7 +195,7 @@ elif [[ "$tvshow" != null ]]; then
             name=$(echo "$episode" | jq -r '.title')
             videoUrl=$(echo "$episode" | jq -r '.videoUrl')
             episode=$(echo "$episode" | jq -r '.episodeNo')
-            filename="S${selectedSeasonFormatted}E$(printf '%02d\n' $episode) - ${name}"
+            filename="${requestedShow}/Season ${selectedSeasonFormatted}/${requestedShow} S${selectedSeasonFormatted}E$(printf '%02d\n' $episode) - ${name}"
             urlParam=$( auth )
             downloadUrl=${videoUrl}?${urlParam}
             echo "Lade ${filename}..."


### PR DESCRIPTION
changes:
- remove carriage return at the end of the token
- flag for automatic downloads without user interaction (especially useful for series / tv shows)
- adjusted naming scheme to fit that of popular media servers like Emby or Jellyfin
- store temporary json content in an unique temporary file to allow multiple simoultaneous downloads