### PR TITLE
Replace slashes in the episode name by a dash

### DIFF
--- a/ard-plus-dl.sh
+++ b/ard-plus-dl.sh
@@ -199,6 +199,10 @@ elif [[ "$tvshow" != null ]]; then
             videoUrl=$(echo "$episode" | jq -r '.videoUrl')
             episode=$(echo "$episode" | jq -r '.episodeNo')
             filename="${requestedShow/\// }/Season ${selectedSeasonFormatted}/${requestedShow/\// } S${selectedSeasonFormatted}E$(printf '%02d\n' $episode) - ${name/\// - }"
+            if [ -e "${filename}.mp4" ]; then
+              echo "Existiert bereits: ${filename}.mp4" >&2
+              continue
+            fi
             urlParam=$( auth )
             downloadUrl=${videoUrl}?${urlParam}
             echo "Lade ${filename}..."

--- a/ard-plus-dl.sh
+++ b/ard-plus-dl.sh
@@ -198,7 +198,7 @@ elif [[ "$tvshow" != null ]]; then
             name=$(echo "$episode" | jq -r '.title')
             videoUrl=$(echo "$episode" | jq -r '.videoUrl')
             episode=$(echo "$episode" | jq -r '.episodeNo')
-            filename="${requestedShow/\// }/Season ${selectedSeasonFormatted}/${requestedShow/\// } S${selectedSeasonFormatted}E$(printf '%02d\n' $episode) - ${name}"
+            filename="${requestedShow/\// }/Season ${selectedSeasonFormatted}/${requestedShow/\// } S${selectedSeasonFormatted}E$(printf '%02d\n' $episode) - ${name/\// - }"
             urlParam=$( auth )
             downloadUrl=${videoUrl}?${urlParam}
             echo "Lade ${filename}..."


### PR DESCRIPTION
Otherwise, video files will get put into subdirectories.

While we are at it:

Continue the loop if file already exists
    
This avoids having to wait for yt-dlp to find out that the file was  already downloaded.