### PR TITLE
Handle shows where the season numbers do not correspond to their index

### DIFF
--- a/ard-plus-dl.sh
+++ b/ard-plus-dl.sh
@@ -164,7 +164,14 @@ elif [[ "$tvshow" != null ]]; then
     if [ $automatic_download -eq 0 ]
     then
         echo -n "Welche Staffel möchtest du runterladen? "
-        read -r selectedSeasonList
+        read -r selectedSeasonNumber
+        selectedSeasonList=$(echo "$seasonIds" | jq -r 'map(.season == '"$selectedSeasonNumber"') | index(true)')
+        if [ "$selectedSeasonList" = "null" ]; then
+          echo "Gewählte Staffel nicht Teil der Liste" >&2
+          exit 1
+        fi
+        # the code assumes a 1-based index
+        selectedSeasonList=$((selectedSeasonList+1))
     else
         selectedSeasonList=$(seq 1 $seasonCount)
     fi
@@ -173,6 +180,7 @@ elif [[ "$tvshow" != null ]]; then
     for selectedSeason in $selectedSeasonList
     do
         selectedSeasonId=$(echo "$seasonIds" | jq -r --argjson index 1 ".[$((selectedSeason - 1))].seasonId")
+        selectedSeasonNumber=$(echo "$seasonIds" | jq -r --argjson index 1 ".[$((selectedSeason - 1))].season")
 
         seasonData=$("$curlBin" -s "https://data.ardplus.de/ard/graphql?extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22134d75e1e68a9599d1cdccf790839d9d71d2e7d7dca57d96f95285fcfd02b2ae%22%7D%7D&variables=%7B%22seasonId%22%3A%22$selectedSeasonId%22%7D&operationName=EpisodesInSeasonData" \
         -H 'authority: data.ardplus.de' \
@@ -183,8 +191,8 @@ elif [[ "$tvshow" != null ]]; then
         -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36')
         episodes=$(echo $seasonData | jq '[.data.episodes.nodes[] | { id: .id, episodeNo: .episodeInSeason, title: .title, videoUrl: .videoSource.dashUrl }]')
         amount=$(echo $episodes | jq '. | length')
-        echo -e "\nStaffel $selectedSeason hat $amount Folgen."
-        selectedSeasonFormatted=$(printf '%02d\n' "$selectedSeason")
+        echo -e "\nStaffel $selectedSeasonNumber hat $amount Folgen."
+        selectedSeasonFormatted=$(printf '%02d\n' "$selectedSeasonNumber")
 
         if [[ $skip != "1" ]]; then
             echo "Überspringe $skip Episode(n)."


### PR DESCRIPTION
Before:

----%<-------------------------------------------------------------------- $ ard-plus-dl https://www.ardplus.de/details/a0T010000001ijv-es-war-einmal user pass

Gewünschte Serie: Es war einmal...

Option  Titel
------  -----
2       Es war einmal… der Weltraum

Welche Staffel möchtest du runterladen? 2

Staffel 2 hat 0 Folgen.
---->%--------------------------------------------------------------------

Problem: selecting the displayed option number will choose an index that does not exist. In this case, the user has to "lie" to the program and select the actual 1-based index:

----%<-------------------------------------------------------------------- $ ard-plus-dl https://www.ardplus.de/details/a0T010000001ijv-es-war-einmal user pass

Gewünschte Serie: Es war einmal...

Option  Titel
------  -----
2       Es war einmal… der Weltraum

Welche Staffel möchtest du runterladen? 1

Staffel 1 hat 26 Folgen.
Lade Es war einmal.../Season 01/Es war einmal... S01E01 - Der Planet Omega... ---->%--------------------------------------------------------------------

But then the results get stored in a directory with the wrong season number.

This commit fixes both issues:

 1. It translates the season number entered by the user into the actual season index by searching for a season with that number in $seasonIds

 2. It translates the season index to the actual season number by looking up the .season property in $seasonIds so that the directory is correctly named

After:

----%<-------------------------------------------------------------------- $ ard-plus-dl https://www.ardplus.de/details/a0T010000001ijv-es-war-einmal user pass

Gewünschte Serie: Es war einmal...

Option  Titel
------  -----
2       Es war einmal… der Weltraum

Welche Staffel möchtest du runterladen? 2

Staffel 2 hat 26 Folgen.
Lade Es war einmal.../Season 02/Es war einmal... S02E01 - Der Planet Omega... ---->%--------------------------------------------------------------------